### PR TITLE
[fix][#67] 카드, 메모 리스트 정렬 조건 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
         stage('Build & Test') {
             steps {
                 script {
+                    sh 'mkdir -p $WORKSPACE/src/main/resources/static/docs && touch $WORKSPACE/src/main/resources/static/docs/open-api-3.0.1.json'
                     sh './gradlew clean build'
                     sh './gradlew openapi3'
                 }

--- a/src/main/java/com/server/bbo_gak/domain/card/service/CardInRecruitService.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/service/CardInRecruitService.java
@@ -23,6 +23,7 @@ import com.server.bbo_gak.domain.recruit.entity.Recruit;
 import com.server.bbo_gak.domain.user.entity.User;
 import com.server.bbo_gak.global.error.exception.ErrorCode;
 import com.server.bbo_gak.global.error.exception.NotFoundException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -62,6 +63,7 @@ public class CardInRecruitService {
             recruitId);
 
         return cards.stream()
+            .sorted(Comparator.comparing(Card::getUpdatedDate).reversed())
             .map(card -> CardListGetResponse.of(card, card.getCardTagList()))
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/server/bbo_gak/domain/card/service/CardMemoService.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/service/CardMemoService.java
@@ -11,6 +11,7 @@ import com.server.bbo_gak.domain.card.entity.CardMemo;
 import com.server.bbo_gak.domain.user.entity.User;
 import com.server.bbo_gak.global.error.exception.ErrorCode;
 import com.server.bbo_gak.global.error.exception.NotFoundException;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,7 @@ public class CardMemoService {
 
         return card.getCardMemoList().stream()
             .map(CardMemoGetResponse::from)
+            .sorted(Comparator.comparing(CardMemoGetResponse::updatedDate).reversed())
             .toList();
     }
 

--- a/src/main/java/com/server/bbo_gak/domain/card/service/CardService.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/service/CardService.java
@@ -20,6 +20,7 @@ import com.server.bbo_gak.domain.card.entity.CardTypeValueGroup;
 import com.server.bbo_gak.domain.user.entity.User;
 import com.server.bbo_gak.global.error.exception.ErrorCode;
 import com.server.bbo_gak.global.error.exception.NotFoundException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -65,6 +66,7 @@ public class CardService {
             null);
 
         return cards.stream()
+            .sorted(Comparator.comparing(Card::getUpdatedDate).reversed())
             .map(card -> CardListGetResponse.of(card, card.getCardTagList()))
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #67

## 📌 작업 내용 및 특이사항
- 카드, 메모 리스트 정렬 조건 추가
- 젠킨스 빌드시 open api json 파일이 없을 경우 계속 버그 발생 -> 빈 json 파일 생성 후 빌드.

## 📝 참고사항
- open api json 파일이 없을 경우 계속 버그 발생 -> 로컬에서도 가끔이랬는데,, 왜그런지 모르겠네요? 크게 중요하지는 않아서 빈파일 만들고 시작하는걸로 합의

## 📚 기타
- na
