### PR TITLE
[Feature/#69] 카드 태그의 추가 작업 #69

### DIFF
--- a/src/main/java/com/server/bbo_gak/domain/card/controller/CardController.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/controller/CardController.java
@@ -66,7 +66,6 @@ public class CardController {
         @PathVariable("card-id") Long cardId,
         @RequestBody CardTypeUpdateRequest request
     ) {
-
         cardService.updateCardType(user, cardId, request);
         return ResponseEntity.ok().body(null);
     }

--- a/src/main/java/com/server/bbo_gak/domain/card/controller/CardController.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/controller/CardController.java
@@ -3,6 +3,7 @@ package com.server.bbo_gak.domain.card.controller;
 import com.server.bbo_gak.domain.card.dto.request.CardContentUpdateRequest;
 import com.server.bbo_gak.domain.card.dto.request.CardCreateRequest;
 import com.server.bbo_gak.domain.card.dto.request.CardTitleUpdateRequest;
+import com.server.bbo_gak.domain.card.dto.request.CardTypeUpdateRequest;
 import com.server.bbo_gak.domain.card.dto.response.CardCreateResponse;
 import com.server.bbo_gak.domain.card.dto.response.CardGetResponse;
 import com.server.bbo_gak.domain.card.dto.response.CardListGetResponse;
@@ -57,6 +58,17 @@ public class CardController {
         @RequestBody CardCreateRequest cardCreateRequest) {
 
         return ResponseEntity.ok(cardService.createCard(user, cardCreateRequest));
+    }
+
+    @PutMapping("/cards/{card-id}/card-type")
+    public ResponseEntity<Void> updateCardType(
+        @AuthUser User user,
+        @PathVariable("card-id") Long cardId,
+        @RequestBody CardTypeUpdateRequest request
+    ) {
+
+        cardService.updateCardType(user, cardId, request);
+        return ResponseEntity.ok().body(null);
     }
 
     @PutMapping("/cards/{card-id}/title")

--- a/src/main/java/com/server/bbo_gak/domain/card/controller/CardController.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/controller/CardController.java
@@ -47,9 +47,11 @@ public class CardController {
     @GetMapping("/cards")
     public ResponseEntity<List<CardListGetResponse>> getCardList(
         @AuthUser User user,
-        @RequestParam("type") String type) {
+        @RequestParam("type") String type,
+        @RequestParam(value = "tag-ids", required = false) List<Long> tagIdList
+    ) {
 
-        return ResponseEntity.ok(cardService.getCardList(user, type));
+        return ResponseEntity.ok(cardService.getCardList(user, type, tagIdList));
     }
 
     @PostMapping("/card")

--- a/src/main/java/com/server/bbo_gak/domain/card/controller/CardInRecruitController.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/controller/CardInRecruitController.java
@@ -29,12 +29,13 @@ public class CardInRecruitController {
     }
 
     @GetMapping("/recruits/{recruit-id}/cards")
-    public ResponseEntity<List<CardListGetResponse>> getCardDetail(
+    public ResponseEntity<List<CardListGetResponse>> getCardList(
         @AuthUser User user,
         @PathVariable("recruit-id") Long recruitId,
-        @RequestParam("type") String type) {
+        @RequestParam("type") String type,
+        @RequestParam(value = "tag-ids", required = false) List<Long> tagIdList) {
 
-        return ResponseEntity.ok(cardInRecruitService.getCardListInRecruit(user, recruitId, type));
+        return ResponseEntity.ok(cardInRecruitService.getCardListInRecruit(user, recruitId, type, tagIdList));
     }
 
     @PostMapping("/recruits/{recruit-id}/cards/{card-id}")

--- a/src/main/java/com/server/bbo_gak/domain/card/controller/TagController.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/controller/TagController.java
@@ -22,8 +22,10 @@ public class TagController {
     private final TagService tagService;
 
     @GetMapping("/tags")
-    public ResponseEntity<List<TagGetResponse>> getAllTagList() {
-        return ResponseEntity.ok(tagService.getAllTagList());
+    public ResponseEntity<List<TagGetResponse>> getAllTagList(
+        @AuthUser User user
+    ) {
+        return ResponseEntity.ok(tagService.getAllTagList(user));
     }
 
     @GetMapping("/cards/{card-id}/tags")

--- a/src/main/java/com/server/bbo_gak/domain/card/dao/CardDao.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/dao/CardDao.java
@@ -25,8 +25,6 @@ public class CardDao {
         QCard qCard = QCard.card;
         QCardType qCardType = QCardType.cardType;
 
-        createRecruitBooleanBuilder(qCard, isRecruit);
-
         return query.selectFrom(qCard)
             .leftJoin(qCard.cardTypeList, qCardType).fetchJoin()
             .where(qCard.user.id.eq(user.getId())
@@ -41,13 +39,12 @@ public class CardDao {
         QCard qCard = QCard.card;
         QCardType qCardType = QCardType.cardType;
 
-        createRecruitBooleanBuilder(qCard, recruitId);
-
         return query.selectFrom(qCard)
             .leftJoin(qCard.cardTypeList, qCardType).fetchJoin()
             .where(qCard.user.id.eq(user.getId())
                 .and(qCardType.cardTypeValue.eq(cardTypeValue))
-                .and(createRecruitBooleanBuilder(qCard, recruitId)))
+                .and(createRecruitBooleanBuilder(qCard, recruitId))
+            )
             .distinct()
             .fetch();
     }
@@ -72,6 +69,5 @@ public class CardDao {
         }
 
         return builder.and(qCard.recruit.id.eq(recruitId)).and(qCard.copyFlag.isTrue());
-
     }
 }

--- a/src/main/java/com/server/bbo_gak/domain/card/dao/CardRepository.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/dao/CardRepository.java
@@ -11,4 +11,5 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     Optional<Card> findByIdAndUser(Long id, User user);
 
     List<Card> findAllByUser(User user);
+
 }

--- a/src/main/java/com/server/bbo_gak/domain/card/dao/TagRepository.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/dao/TagRepository.java
@@ -1,10 +1,13 @@
 package com.server.bbo_gak.domain.card.dao;
 
 import com.server.bbo_gak.domain.card.entity.Tag;
+import com.server.bbo_gak.domain.user.entity.Job;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    List<Tag> findAllByJob(Job job);
 
     List<Tag> findAllByIdIsNotIn(List<Long> idList);
 

--- a/src/main/java/com/server/bbo_gak/domain/card/dto/request/CardCreateRequest.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/dto/request/CardCreateRequest.java
@@ -9,7 +9,9 @@ public record CardCreateRequest(
     List<String> cardTypeValueList,
 
     @Size(max = 3)
-    List<Long> tagIdList
+    List<Long> tagIdList,
+
+    String cardTypeValueGroup
 ) {
 
 }

--- a/src/main/java/com/server/bbo_gak/domain/card/dto/request/CardTypeUpdateRequest.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/dto/request/CardTypeUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.server.bbo_gak.domain.card.dto.request;
+
+import java.util.List;
+
+public record CardTypeUpdateRequest(
+    List<String> typeList
+) {
+
+}

--- a/src/main/java/com/server/bbo_gak/domain/card/dto/request/CardTypeUpdateRequest.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/dto/request/CardTypeUpdateRequest.java
@@ -3,7 +3,9 @@ package com.server.bbo_gak.domain.card.dto.request;
 import java.util.List;
 
 public record CardTypeUpdateRequest(
-    List<String> typeList
+    List<String> cardTypeValueList,
+
+    String cardTypeValueGroup
 ) {
 
 }

--- a/src/main/java/com/server/bbo_gak/domain/card/entity/Card.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/entity/Card.java
@@ -109,5 +109,9 @@ public class Card extends BaseEntity {
         this.content = content;
     }
 
+    public void updateCardTypeList(List<CardType> cardTypeList) {
+        this.cardTypeList = cardTypeList;
+    }
+
 
 }

--- a/src/main/java/com/server/bbo_gak/domain/card/entity/Card.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/entity/Card.java
@@ -113,5 +113,11 @@ public class Card extends BaseEntity {
         this.cardTypeList = cardTypeList;
     }
 
+    public boolean isTagListContain(List<Tag> tagList) {
+        return cardTagList.stream()
+            .map(CardTag::getTag)
+            .anyMatch(tagList::contains);
+    }
+
 
 }

--- a/src/main/java/com/server/bbo_gak/domain/card/entity/CardTypeValueGroup.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/entity/CardTypeValueGroup.java
@@ -1,5 +1,7 @@
 package com.server.bbo_gak.domain.card.entity;
 
+import com.server.bbo_gak.global.error.exception.ErrorCode;
+import com.server.bbo_gak.global.error.exception.NotFoundException;
 import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,13 +10,21 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CardTypeValueGroup {
 
-    MY_INFO(new CardTypeValue[]{CardTypeValue.EXPERIENCE, CardTypeValue.INTERVIEW_QUESTION,
+    MY_INFO("내_정보", new CardTypeValue[]{CardTypeValue.EXPERIENCE, CardTypeValue.INTERVIEW_QUESTION,
         CardTypeValue.PERSONAL_STATEMENT}),
 
-    RECRUIT(new CardTypeValue[]{CardTypeValue.ASSIGNMENT_PREPARING, CardTypeValue.DOCUMENT_PREPARING,
+    RECRUIT("공고", new CardTypeValue[]{CardTypeValue.ASSIGNMENT_PREPARING, CardTypeValue.DOCUMENT_PREPARING,
         CardTypeValue.INTERVIEW_PREPARING});
 
+    private String value;
     private CardTypeValue[] cardTypeValueList;
+
+    public static CardTypeValueGroup findByValue(String value) {
+        return Arrays.stream(CardTypeValueGroup.values())
+            .filter(cardType -> cardType.getValue().equals(value))
+            .findFirst()
+            .orElseThrow((() -> new NotFoundException(ErrorCode.CARD_TYPE_VALUE_GROUP_NOT_FOUND)));
+    }
 
     public boolean contains(CardTypeValue cardTypeValue) {
         return Arrays.asList(cardTypeValueList).contains(cardTypeValue);

--- a/src/main/java/com/server/bbo_gak/domain/card/entity/CardTypeValueGroup.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/entity/CardTypeValueGroup.java
@@ -1,5 +1,6 @@
 package com.server.bbo_gak.domain.card.entity;
 
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,6 +13,10 @@ public enum CardTypeValueGroup {
 
     RECRUIT(new CardTypeValue[]{CardTypeValue.ASSIGNMENT_PREPARING, CardTypeValue.DOCUMENT_PREPARING,
         CardTypeValue.INTERVIEW_PREPARING});
-    
+
     private CardTypeValue[] cardTypeValueList;
+
+    public boolean contains(CardTypeValue cardTypeValue) {
+        return Arrays.asList(cardTypeValueList).contains(cardTypeValue);
+    }
 }

--- a/src/main/java/com/server/bbo_gak/domain/card/entity/Tag.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/entity/Tag.java
@@ -1,5 +1,6 @@
 package com.server.bbo_gak.domain.card.entity;
 
+import com.server.bbo_gak.domain.user.entity.Job;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -23,6 +24,9 @@ public class Tag {
 
     @Enumerated(EnumType.STRING)
     private TagType tagType;
+
+    @Enumerated(EnumType.STRING)
+    private Job job;
 
     private String name;
 }

--- a/src/main/java/com/server/bbo_gak/domain/card/service/TagService.java
+++ b/src/main/java/com/server/bbo_gak/domain/card/service/TagService.java
@@ -25,8 +25,9 @@ public class TagService {
     private final CardTagRepository cardTagRepository;
 
     @Transactional(readOnly = true)
-    public List<TagGetResponse> getAllTagList() {
-        return tagRepository.findAll().stream()
+    public List<TagGetResponse> getAllTagList(User user) {
+
+        return tagRepository.findAllByJob(user.getJob()).stream()
             .map(TagGetResponse::from)
             .toList();
     }

--- a/src/main/java/com/server/bbo_gak/domain/user/entity/Job.java
+++ b/src/main/java/com/server/bbo_gak/domain/user/entity/Job.java
@@ -1,0 +1,14 @@
+package com.server.bbo_gak.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Job {
+    ALL("공통"),
+    DESIGNER("디자이너"),
+    DEVELOPER("개발자");
+
+    private final String value;
+}

--- a/src/main/java/com/server/bbo_gak/domain/user/entity/User.java
+++ b/src/main/java/com/server/bbo_gak/domain/user/entity/User.java
@@ -1,7 +1,15 @@
 package com.server.bbo_gak.domain.user.entity;
 
 import com.server.bbo_gak.global.common.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,11 +33,15 @@ public class User extends BaseEntity {
     @Embedded
     private OauthInfo oauthInfo;
 
+    @Enumerated(EnumType.STRING)
+    private Job job;
+
     // User 생성 팩토리 메서드
     public static User from(OauthInfo oauthInfo) {
         return User.builder()
-                .role(UserRole.USER)
-                .oauthInfo(oauthInfo)
-                .build();
+            .role(UserRole.USER)
+            .oauthInfo(oauthInfo)
+            .job(Job.DEVELOPER)
+            .build();
     }
 }

--- a/src/main/java/com/server/bbo_gak/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/server/bbo_gak/global/error/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
     //User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 직업을 찾을 수 없습니다"),
 
     //Image
     IMAGE_FILE_EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 확장자입니다."),
@@ -40,10 +41,12 @@ public enum ErrorCode {
     //Card
     CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카드를 찾을 수 없습니다"),
     CARD_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카드 타입을 찾을 수 없습니다"),
+    CARD_TYPE_VALUE_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카드 타입 그룹(내 정보 or 공고)을 찾을 수 없습니다."),
+    CARD_TYPE_NOT_MATCHED(HttpStatus.BAD_REQUEST, "카드 타입이 맞지 않습니다"),
+    MY_INFO_CARD_TYPE_OVERSIZE(HttpStatus.BAD_REQUEST, "내 정보에서는 하나의 카드 타입만 할당 가능합니다."),
 
     //Tag
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 태그를 찾을 수 없습니다"),
-
     TAG_DUPLICATED(HttpStatus.BAD_REQUEST, "해당 태그가 이미 추가 돼있습니다."),
 
     //Season
@@ -53,8 +56,6 @@ public enum ErrorCode {
     RECRUIT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공고를 찾을 수 없습니다"),
     RECRUIT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공고 지원 상태를 찾을 수 없습니다"),
     RECRUIT_SCHEDULE_STAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공고 일정 단계를 찾을 수 없습니다"),
-
-
     CARD_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카드와 태그 매핑을 찾을 수 없습니다"),
 
     //CardMemo

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -11,3 +11,5 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+        default_batch_fetch_size: 1000
+

--- a/src/test/java/com/server/bbo_gak/domain/card/controller/CardControllerTest.java
+++ b/src/test/java/com/server/bbo_gak/domain/card/controller/CardControllerTest.java
@@ -128,7 +128,8 @@ public class CardControllerTest extends AbstractRestDocsTests {
     @Nested
     class 카드_신규_생성 {
 
-        CardCreateRequest request = new CardCreateRequest(Arrays.asList("경험_정리", "자기소개서"), Arrays.asList(1L, 2L));
+        CardCreateRequest request = new CardCreateRequest(Arrays.asList("경험_정리"), Arrays.asList(1L, 2L),
+            "내_정보");
 
         @Test
         @Transactional
@@ -139,8 +140,11 @@ public class CardControllerTest extends AbstractRestDocsTests {
                 .andExpect(status().isOk()).andDo(document("[create] 카드 신규 생성", preprocessResponse(prettyPrint()),
                     resource(ResourceSnippetParameters.builder().description("카드 신규 생성").tags("Card")
                         .requestSchema(Schema.schema("CardCreateRequest"))
-                        .requestFields(fieldWithPath("cardTypeValueList").type(JsonFieldType.ARRAY).description("카드 타입값"),
-                            fieldWithPath("tagIdList").type(JsonFieldType.ARRAY).description("태그 ID"))
+                        .requestFields(
+                            fieldWithPath("cardTypeValueList").type(JsonFieldType.ARRAY).description("카드 타입값"),
+                            fieldWithPath("tagIdList").type(JsonFieldType.ARRAY).description("태그 ID"),
+                            fieldWithPath("cardTypeValueGroup").type(JsonFieldType.STRING).description("카드 타입 그룹값")
+                        )
                         .responseSchema(Schema.schema("CardCreateResponse"))
                         .responseFields(fieldWithPath("cardId").type(JsonFieldType.NUMBER).description("Card ID"))
                         .build())));

--- a/src/test/java/com/server/bbo_gak/domain/card/controller/TagControllerTest.java
+++ b/src/test/java/com/server/bbo_gak/domain/card/controller/TagControllerTest.java
@@ -51,7 +51,7 @@ public class TagControllerTest extends AbstractRestDocsTests {
             // TEST
             ResultActions resultActions = mockMvc.perform(getRequest())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(2)));
+                .andExpect(jsonPath("$", hasSize(3)));
 
             // DOCS
             resultActions.andDo(document("[태그_전체_목록_조회] 성공", resource(getSuccessResponseResource())));

--- a/src/test/java/com/server/bbo_gak/domain/card/controller/TagControllerTest.java
+++ b/src/test/java/com/server/bbo_gak/domain/card/controller/TagControllerTest.java
@@ -51,7 +51,7 @@ public class TagControllerTest extends AbstractRestDocsTests {
             // TEST
             ResultActions resultActions = mockMvc.perform(getRequest())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(3)));
+                .andExpect(jsonPath("$", hasSize(2)));
 
             // DOCS
             resultActions.andDo(document("[태그_전체_목록_조회] 성공", resource(getSuccessResponseResource())));

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,6 +15,7 @@ spring:
         show_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+        default_batch_fetch_size: 1000
 
 cloud:
   aws:

--- a/src/test/resources/auth-test-data.sql
+++ b/src/test/resources/auth-test-data.sql
@@ -17,12 +17,12 @@ from recruit_season;
 delete
 from users;
 
-INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role)
+INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role, job)
 VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, 'AuthTestUser', 'email', 'test', 'test',
-        'test123', 'USER');
+        'test123', 'USER', 'DEVELOPER');
 
-INSERT INTO users( deleted, created_at, update_at, user_id, dtype, role, oauth_id, name, email, provider)
-VALUES(false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 2, 'User', 'USER', 'oauthId', 'name', 'email', 'GOOGLE');
+INSERT INTO users( deleted, created_at, update_at, user_id, dtype, role, oauth_id, name, email, provider, job)
+VALUES(false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 2, 'User', 'USER', 'oauthId', 'name', 'email', 'GOOGLE', 'DEVELOPER');
 
 INSERT INTO refresh_token (id, token)
 VALUES (1, 'abcd1234');

--- a/src/test/resources/card-test-data.sql
+++ b/src/test/resources/card-test-data.sql
@@ -1,6 +1,6 @@
-INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role)
+INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role, job)
 VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, 'AuthTestUser', 'test', 'test', 'test',
-        'test', 'USER');
+        'test', 'USER', 'DEVELOPER');
 
 INSERT INTO recruit_season (recruit_season_id, name, user_id)
 VALUES (1, 'test', 1);
@@ -31,12 +31,12 @@ INSERT INTO card (deleted, copy_flag, access_time, card_id, created_at, update_a
 VALUES (false, true, '2024-07-24 21:22:04.000000', 6, '2024-07-24 21:22:07.000000', '2024-07-24 21:22:08.000000', 1,
         'test_contents', 'test_title', 1);
 
-INSERT INTO tag (tag_id, name, tag_type)
-VALUES (1, '스프링', 'CAPABILITY');
-INSERT INTO tag (tag_id, name, tag_type)
-VALUES (2, '리액트', 'CAPABILITY');
-INSERT INTO tag (tag_id, name, tag_type)
-VALUES (3, '봉사활동', 'PERSONALITY');
+INSERT INTO tag (tag_id, name, tag_type, job)
+VALUES (1, '스프링', 'CAPABILITY', 'DEVELOPER');
+INSERT INTO tag (tag_id, name, tag_type, job)
+VALUES (2, '리액트', 'CAPABILITY', 'DEVELOPER');
+INSERT INTO tag (tag_id, name, tag_type, job)
+VALUES (3, '봉사활동', 'PERSONALITY', 'DESIGNER');
 
 INSERT INTO card_type (card_type_id, card_type_value, card_id, deleted, update_at, created_at)
 VALUES (1, 'EXPERIENCE', 1, false, '2024-07-24 21:26:28.000000', '2024-07-24 21:26:28.000000');

--- a/src/test/resources/card-test-data.sql
+++ b/src/test/resources/card-test-data.sql
@@ -36,7 +36,9 @@ VALUES (1, '스프링', 'CAPABILITY', 'DEVELOPER');
 INSERT INTO tag (tag_id, name, tag_type, job)
 VALUES (2, '리액트', 'CAPABILITY', 'DEVELOPER');
 INSERT INTO tag (tag_id, name, tag_type, job)
-VALUES (3, '봉사활동', 'PERSONALITY', 'DESIGNER');
+VALUES (3, '알고리즘', 'CAPABILITY', 'DEVELOPER');
+INSERT INTO tag (tag_id, name, tag_type, job)
+VALUES (4, '봉사활동', 'PERSONALITY', 'DESIGNER');
 
 INSERT INTO card_type (card_type_id, card_type_value, card_id, deleted, update_at, created_at)
 VALUES (1, 'EXPERIENCE', 1, false, '2024-07-24 21:26:28.000000', '2024-07-24 21:26:28.000000');
@@ -76,7 +78,17 @@ VALUES (false, 1, 1, '2024-07-24 21:26:28.000000', 1, '2024-07-24 21:26:40.00000
 INSERT INTO card_tag (deleted, card_id, card_tag_id, created_at, tag_id, update_at)
 VALUES (false, 1, 2, '2024-07-24 21:26:29.000000', 2, '2024-07-24 21:26:41.000000');
 INSERT INTO card_tag (deleted, card_id, card_tag_id, created_at, tag_id, update_at)
-VALUES (false, 2, 3, '2024-07-24 21:26:31.000000', 2, '2024-07-24 21:26:42.000000');
+VALUES (false, 2, 3, '2024-07-24 21:26:28.000000', 2, '2024-07-24 21:26:40.000000');
+INSERT INTO card_tag (deleted, card_id, card_tag_id, created_at, tag_id, update_at)
+VALUES (false, 2, 4, '2024-07-24 21:26:29.000000', 3, '2024-07-24 21:26:41.000000');
+INSERT INTO card_tag (deleted, card_id, card_tag_id, created_at, tag_id, update_at)
+VALUES (false, 3, 5, '2024-07-24 21:26:31.000000', 2, '2024-07-24 21:26:42.000000');
+INSERT INTO card_tag (deleted, card_id, card_tag_id, created_at, tag_id, update_at)
+VALUES (false, 3, 6, '2024-07-24 21:26:31.000000', 3, '2024-07-24 21:26:42.000000');
+INSERT INTO card_tag (deleted, card_id, card_tag_id, created_at, tag_id, update_at)
+VALUES (false, 4, 7, '2024-07-24 21:26:31.000000', 4, '2024-07-24 21:26:42.000000');
+INSERT INTO card_tag (deleted, card_id, card_tag_id, created_at, tag_id, update_at)
+VALUES (false, 4, 8, '2024-07-24 21:26:31.000000', 4, '2024-07-24 21:26:42.000000');
 
 INSERT INTO card_memo (deleted, card_id, card_memo_id, created_at, content, update_at)
 VALUES (false, 1, 1, '2024-07-24 21:26:31.000000', 'test contents 111', '2024-07-24 21:26:42.000000');

--- a/src/test/resources/image-test-data.sql
+++ b/src/test/resources/image-test-data.sql
@@ -1,5 +1,4 @@
-INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role)
+INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role, job)
 VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, 'AuthTestUser', null, 'test', 'test',
-        'test',
-        'USER');
+        'test', 'USER', 'DEVELOPER');
 

--- a/src/test/resources/notification-test-data.sql
+++ b/src/test/resources/notification-test-data.sql
@@ -1,7 +1,6 @@
-INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role)
+INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role, job)
 VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, 'AuthTestUser', null, 'test', 'test',
-        'test',
-        'USER');
+        'test', 'USER', 'DEVELOPER');
 
 -- 다음으로 recruit_season 테이블에 데이터를 삽입합니다.
 INSERT INTO recruit_season (recruit_season_id, name, user_id)

--- a/src/test/resources/recruit-test-data.sql
+++ b/src/test/resources/recruit-test-data.sql
@@ -1,10 +1,10 @@
-INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role)
+INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role, job)
 VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, 'AuthTestUser', 'test', 'test', 'test',
-        'test', 'USER'),
+        'test', 'USER', 'DEVELOPER'),
        (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 2, 'AuthTestUser', 'test', 'test', 'test',
-        'test', 'USER'),
+        'test', 'USER', 'DEVELOPER'),
        (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 3, 'AuthTestUser', 'test', 'test', 'test',
-        'test', 'USER')
+        'test', 'USER', 'DEVELOPER')
 ;
 
 -- Season 테이블에 데이터 삽입

--- a/src/test/resources/season-test-data.sql
+++ b/src/test/resources/season-test-data.sql
@@ -1,8 +1,8 @@
-INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role)
+INSERT INTO users (deleted, created_at, update_at, user_id, dtype, email, login_id, name, password, role, job)
 VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, 'AuthTestUser', 'email', 'test', 'test',
-        'test123', 'USER'),
+        'test123', 'USER', 'DEVELOPER'),
        (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 2, 'AuthTestUser', 'email', 'test', 'test',
-        'test123', 'USER');
+        'test123', 'USER', 'DEVELOPER');
 
 INSERT INTO recruit_season (recruit_season_id, name, user_id)
 VALUES (1, '2024 상반기', 2),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #69 

## 📌 작업 내용 및 특이사항
1. 태그 전체 조회  api (GET /api/v1/tags)
- 조회 시, 자기 직군(디자이너 or 개발자)만 조회 되게끔

2. 카드 생성 api (POST /api/v1/card), 카드 공고로 복사 api (POST /api/v1/recruits/1/cards)
- 같은 태그 타입이 아닐 경우, 예외 처리
- 내정보는 타입 하나만 추가 가능(마이 인포랑, 리쿠르트랑 다름)

3. 타입 변경 api 신규 개발 ( POST /cards/{card-id}/card-type)

## 📝 참고사항
- n/a

## 📚 기타
- n/a
