### PR TITLE
[fix][#93] 테스트 온보딩 상태 조회 api 이름 겹치는 부분 수정

### DIFF
--- a/src/test/java/com/server/bbo_gak/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/server/bbo_gak/domain/user/controller/UserControllerTest.java
@@ -56,7 +56,7 @@ public class UserControllerTest extends AbstractRestDocsTests {
       mockMvc.perform(restDocsFactory.createRequest(DEFAULT_URL + "/onboard-status", null, HttpMethod.GET,
               objectMapper))
           .andExpect(status().isOk())
-          .andDo(restDocsFactory.getSuccessResource("[온보딩상태_조회] 성공", "온보딩상태 조회", "user", null, response));
+          .andDo(restDocsFactory.getSuccessResource("[온보딩상태_조회] 성공-온보딩 완료 상태", "온보딩상태 조회", "user", null, response));
 
     }
 
@@ -70,7 +70,7 @@ public class UserControllerTest extends AbstractRestDocsTests {
       mockMvc.perform(restDocsFactory.createRequest(DEFAULT_URL + "/onboard-status", null, HttpMethod.GET,
               objectMapper))
           .andExpect(status().isOk())
-          .andDo(restDocsFactory.getSuccessResource("[온보딩상태_조회] 성공", "온보딩상태 조회", "user", null, response));
+          .andDo(restDocsFactory.getSuccessResource("[온보딩상태_조회] 성공-온보딩 미완료 상태", "온보딩상태 조회", "user", null, response));
 
     }
   }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
-  온보딩 상태 조회시(온보딩 완료상태, 온보딩 미완료 상태 둘다 case 보여주기)

## 📝 참고사항
- 

## 📚 기타
- 
